### PR TITLE
Bump dependencies. Drop Scala.js 0.6 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: true
 language: scala
 
 scala:
-  - 2.12.10
-  - 2.13.1
+  - 2.12.11
+  - 2.13.3
 
 dist: trusty
 group: edge
@@ -12,17 +12,13 @@ jdk:
   - openjdk8
   - openjdk11
 
-env:
-  - SCALAJS_VERSION=0.6.32
-  - SCALAJS_VERSION=1.0.0
-
 cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot
 
-# coverage temporary disabled
-# sbt ++$TRAVIS_SCALA_VERSION coverageReport;
+# coverage temporary disabledcoverage
+# sbt ++$TRAVIS_SCALA_VERSION Report;
 script:
   - sbt ++$TRAVIS_SCALA_VERSION clean validate
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: true
 language: scala
 
 scala:
-  - 2.12.11
+  - 2.12.12
   - 2.13.3
 
 dist: trusty
@@ -17,9 +17,7 @@ cache:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot
 
-# coverage temporary disabledcoverage
-# sbt ++$TRAVIS_SCALA_VERSION Report;
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION clean validate
+  - sbt ++$TRAVIS_SCALA_VERSION clean coverage validate && sbt ++$TRAVIS_SCALA_VERSION coverageReport;
 
 after_success: bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 lazy val buildSettings = Seq(
   organization := "ru.pavkin",
-  scalaVersion := "2.12.10",
-  crossScalaVersions := Seq("2.12.10", "2.13.1")
+  scalaVersion := "2.12.11",
+  crossScalaVersions := Seq("2.12.11", "2.13.3")
 )
 
 lazy val compilerOptions = Seq(
@@ -19,17 +19,17 @@ lazy val compilerOptions = Seq(
 )
 
 
-lazy val catsVersion = "2.1.1"
+lazy val catsVersion = "2.2.0"
 lazy val simulacrumVersion = "1.0.0"
 lazy val scalaJSJavaTimeVersion = "0.2.6"
-lazy val disciplineVersion = "1.0.2"
+lazy val disciplineVersion = "1.0.3"
 lazy val disciplineScalatestVersion = "1.0.1"
-lazy val scalaCheckDateTimeVersion = "0.3.2"
+lazy val scalaCheckDateTimeVersion = "0.3.5"
 lazy val scalaCheckVersion = "1.14.3"
 lazy val scalaTestVersion = "3.1.1"
-lazy val scalaCollectionCompatVersion = "2.1.4"
+lazy val scalaCollectionCompatVersion = "2.1.6"
 
-lazy val momentFacadeVersion = "0.10.3"
+lazy val momentFacadeVersion = "0.10.4"
 
 lazy val macroAnnotationOption = Seq(
   scalacOptions ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 lazy val buildSettings = Seq(
   organization := "ru.pavkin",
-  scalaVersion := "2.12.11",
-  crossScalaVersions := Seq("2.12.11", "2.13.3")
+  scalaVersion := "2.12.12",
+  crossScalaVersions := Seq("2.12.12", "2.13.3")
 )
 
 lazy val compilerOptions = Seq(
@@ -21,12 +21,12 @@ lazy val compilerOptions = Seq(
 
 lazy val catsVersion = "2.2.0"
 lazy val simulacrumVersion = "1.0.0"
-lazy val scalaJSJavaTimeVersion = "0.2.6"
+lazy val scalaJSJavaTimeVersion = "1.0.0"
 lazy val disciplineVersion = "1.0.3"
-lazy val disciplineScalatestVersion = "1.0.1"
+lazy val disciplineScalatestVersion = "2.0.1"
 lazy val scalaCheckDateTimeVersion = "0.3.5"
 lazy val scalaCheckVersion = "1.14.3"
-lazy val scalaTestVersion = "3.1.1"
+lazy val scalaTestVersion = "3.2.2"
 lazy val scalaCollectionCompatVersion = "2.1.6"
 
 lazy val momentFacadeVersion = "0.10.4"

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val scalaCheckVersion = "1.14.3"
 lazy val scalaTestVersion = "3.2.2"
 lazy val scalaCollectionCompatVersion = "2.1.6"
 
-lazy val momentFacadeVersion = "0.10.4"
+lazy val momentFacadeVersion = "0.10.5"
 
 lazy val macroAnnotationOption = Seq(
   scalacOptions ++= {

--- a/laws/shared/src/main/scala/dtc/laws/ProviderLaws.scala
+++ b/laws/shared/src/main/scala/dtc/laws/ProviderLaws.scala
@@ -5,7 +5,6 @@ import cats.Order
 import cats.syntax.order._
 import dtc.{Provider, TimeZoneId}
 import org.scalacheck.Prop.forAll
-import org.scalacheck.Prop
 import org.scalacheck.{Arbitrary, Gen, Prop}
 
 trait ProviderLaws[A] {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.2
+sbt.version = 1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,8 @@ resolvers ++= Seq(
 
 val scalaJSVersion = "1.1.1"
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "scalaJSVersion")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+
 addSbtPlugin("org.scala-js" % "sbt-jsdependencies" % "1.0.2")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.18.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
@@ -17,6 +18,5 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.2")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.1")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,22 +4,11 @@ resolvers ++= Seq(
   "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 )
 
-val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.32")
+val scalaJSVersion = "1.1.1"
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
-
-{
-  if (scalaJSVersion.startsWith("0.6.")) Nil
-  else Seq(addSbtPlugin("org.scala-js" % "sbt-jsdependencies" % scalaJSVersion))
-}
-
-if (scalaJSVersion.startsWith("0.6.")) {
-  addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler-sjs06" % "0.17.0")
-} else {
-  addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.17.0")
-}
-
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "scalaJSVersion")
+addSbtPlugin("org.scala-js" % "sbt-jsdependencies" % "1.0.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.18.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
@@ -29,5 +18,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.2")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.4.0")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers ++= Seq(
   "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 )
 
-val scalaJSVersion = "1.1.1"
+val scalaJSVersion = "1.2.0"
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 


### PR DESCRIPTION
because waiting for next Scala.js release, currently fails with https://github.com/scala-js/scala-js/issues/4168

Upd: Scala.js 1.2.0 released.
